### PR TITLE
2.5.0 Refactor Knight API to require explicit controllers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@knight/knight",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "imports": {


### PR DESCRIPTION
Removed deprecated methods and automatic controller discovery in favor of explicit controller registration. The Knight.build and Knight.start methods now require a list of controllers to be provided, improving clarity and reducing magic. Updated documentation and cleaned up related code. Bumped version to 2.5.0.